### PR TITLE
Fixed bsnes build

### DIFF
--- a/waterbox/bsnescore/Makefile
+++ b/waterbox/bsnescore/Makefile
@@ -7,7 +7,7 @@ CXXFLAGS := -std=c++17 \
 	-Wno-unqualified-std-cast-call -Wno-mismatched-tags -Wno-overloaded-virtual -Wno-bitwise-instead-of-logical \
 	-fno-threadsafe-statics -fno-strict-aliasing -fwrapv
 
-CCFLAGS := -std=c11 -DGB_INTERNAL -DGB_DISABLE_DEBUGGER -DGB_DISABLE_CHEATS -DGB_DISABLE_TIMEKEEPING -D_GNU_SOURCE -DGB_VERSION= \
+CCFLAGS := -std=c11 -DGB_INTERNAL -DGB_DISABLE_DEBUGGER -DGB_DISABLE_CHEATS -DGB_DISABLE_TIMEKEEPING -DGB_DISABLE_REWIND -D_GNU_SOURCE -DGB_VERSION= \
 	-Wall -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-missing-braces -Wno-missing-field-initializers
 
 TARGET = bsnes.wbx


### PR DESCRIPTION
bsnes build broke when rewind.c was removed because it defined the GB_rewind_reset, which was being linked in despite being no longer present. -DGB_DISABLE_REWIND turns off this link.

[//]: # "This description supports Markdown syntax. There's a cheatsheet here: https://guides.github.com/features/mastering-markdown/"
[//]: # "These lines are comments, for letting you know what you should be writing. You can delete them or leave them in."
[//]: # "Also, please remember to link related Issues! If a bug hasn't been reported, you may submit a fix without creating an Issue."

(describe changeset here)

[//]: # "Apart from the mandatory license signature, these tasks are optional, but doing them could save reviewers some time and get the PR merged sooner."
Check if completed:
- [ ] I have run any relevant test suites
- [ ] I, the committer, have read the [licensing terms for contributors](https://github.com/TASEmulators/BizHawk/blob/master/contributing.md#copyrights-and-licensing) (last updated 2024-03-20) and am compliant
